### PR TITLE
Fix end tag mismatch in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
-            <artifactId>poi-ooxml</groupId>
+            <artifactId>poi-ooxml</artifactId>
             <version>5.2.3</version>
         </dependency>
         


### PR DESCRIPTION
Correct the end tag in `pom.xml` to fix the non-parseable POM error.

* Change the end tag `</groupId>` to `</artifactId>` in the dependencies section of `pom.xml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/johnny603/JobFit/pull/5?shareId=1f581bb8-e829-4804-948c-84b55a461432).