### PR TITLE
Fix configuration for multipart file size

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,5 +4,5 @@ spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 
 # File upload settings
 spring.servlet.multipart.enabled=true
-spring.servlet.multipart.max-file-size=10 megabytes
-spring.servlet.multipart.max-request-size=10 megabytes 
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB 


### PR DESCRIPTION
Update application properties to correctly bind multipart file size properties.

* Change `spring.servlet.multipart.max-file-size` to "10MB" in `src/main/resources/application.properties`
* Change `spring.servlet.multipart.max-request-size` to "10MB" in `src/main/resources/application.properties`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/johnny603/JobFit/pull/10?shareId=441ce3c3-aee0-4052-8f97-d20cf3d065bb).