### PR TITLE
Fix error handling by adding custom error controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,3 +170,6 @@ JobFit includes a recruiter dashboard that allows recruiters to manage job posti
 1. **Log in to the web application**.
 2. **Navigate to the recruiter dashboard**.
 3. **Manage job postings and view candidate matches**.
+
+## Custom Error Handling
+JobFit includes a custom error handling setup to provide more user-friendly error messages. The custom error controller handles the `/error` endpoint and returns a custom error message. The default whitelabel error page is disabled in the `application.properties` file.

--- a/src/main/java/com/jobfit/JobFitApplication.java
+++ b/src/main/java/com/jobfit/JobFitApplication.java
@@ -5,12 +5,14 @@ import com.jobfit.model.AnalysisResult;
 import com.jobfit.parser.DocumentParser;
 import com.jobfit.parser.ParserFactory;
 import com.jobfit.recommender.JobRecommender;
+import com.jobfit.controller.CustomErrorController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.context.annotation.Import;
 
 import java.io.File;
 import java.io.IOException;
@@ -21,6 +23,7 @@ import java.util.List;
 @SpringBootApplication
 @RestController
 @RequestMapping("/api")
+@Import(CustomErrorController.class)
 public class JobFitApplication {
     private static final Logger logger = LoggerFactory.getLogger(JobFitApplication.class);
 

--- a/src/main/java/com/jobfit/controller/CustomErrorController.java
+++ b/src/main/java/com/jobfit/controller/CustomErrorController.java
@@ -1,0 +1,26 @@
+package com.jobfit.controller;
+
+import org.springframework.boot.web.servlet.error.ErrorController;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Controller
+public class CustomErrorController implements ErrorController {
+
+    @RequestMapping("/error")
+    @ResponseBody
+    public String handleError(HttpServletRequest request) {
+        Integer statusCode = (Integer) request.getAttribute("javax.servlet.error.status_code");
+        String errorMessage = (String) request.getAttribute("javax.servlet.error.message");
+
+        return String.format("Error occurred with status code %d and message: %s", statusCode, errorMessage);
+    }
+
+    @Override
+    public String getErrorPath() {
+        return "/error";
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,6 @@ spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 spring.servlet.multipart.enabled=true
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
+
+# Disable default whitelabel error page
+server.error.whitelabel.enabled=false


### PR DESCRIPTION
Add custom error handling to address the /error issue causing a 404 Not Found error.

* **CustomErrorController.java**: Create a new class `CustomErrorController` implementing `ErrorController`. Override the `getErrorPath` method to return "/error". Add a method to handle the `/error` endpoint and return a custom error message.
* **JobFitApplication.java**: Import `CustomErrorController` class by adding `@Import(CustomErrorController.class)` annotation.
* **application.properties**: Add `server.error.whitelabel.enabled=false` to disable the default whitelabel error page.
* **README.md**: Add a section to mention the custom error handling setup.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/johnny603/JobFit/pull/11?shareId=f981ec1a-476b-4bb1-a3c2-a688d7aea325).