### PR TITLE
Fix CustomErrorController compilation error

### DIFF
--- a/src/main/java/com/jobfit/controller/CustomErrorController.java
+++ b/src/main/java/com/jobfit/controller/CustomErrorController.java
@@ -18,9 +18,4 @@ public class CustomErrorController implements ErrorController {
 
         return String.format("Error occurred with status code %d and message: %s", statusCode, errorMessage);
     }
-
-    @Override
-    public String getErrorPath() {
-        return "/error";
-    }
 }


### PR DESCRIPTION
Remove the `getErrorPath` method and its `@Override` annotation from `CustomErrorController.java`.

* Remove the `getErrorPath` method from `src/main/java/com/jobfit/controller/CustomErrorController.java`.
* Remove the `@Override` annotation from the `getErrorPath` method in `src/main/java/com/jobfit/controller/CustomErrorController.java`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/johnny603/JobFit/pull/12?shareId=5a28c9aa-a12f-47aa-a76a-e7e44f4e477e).